### PR TITLE
Move local state to the storage to avoid losing it when background script is inactive

### DIFF
--- a/src/api/IBrowserStorageAPI.ts
+++ b/src/api/IBrowserStorageAPI.ts
@@ -3,7 +3,7 @@ import { BrowserStorageChangedEvent } from '../types';
 export interface IBrowserStorageAPI {
   onChanged: BrowserStorageChangedEvent;
   clear(): Promise<void>;
-  get(keys?: string | string[] | object): Promise<object>;
+  get<T>(keys?: T): Promise<T>;
   remove(keys: string | string[]): Promise<void>;
   set(items: object): Promise<void>;
 }

--- a/src/api/chromeSessionStorageAPI.ts
+++ b/src/api/chromeSessionStorageAPI.ts
@@ -1,0 +1,9 @@
+﻿import { IBrowserStorageAPI } from './IBrowserStorageAPI';
+
+export const chromeSessionStorageAPI: IBrowserStorageAPI = {
+  onChanged: chrome.storage.session.onChanged,
+  clear: chrome.storage.session.clear.bind(chrome.storage.session),
+  get: chrome.storage.session.get.bind(chrome.storage.session),
+  remove: chrome.storage.session.remove.bind(chrome.storage.session),
+  set: chrome.storage.session.set.bind(chrome.storage.session),
+};

--- a/src/background.ts
+++ b/src/background.ts
@@ -9,11 +9,19 @@ import { OpenedTabManager } from './managers/OpenedTabManager';
 import { TabAlarmManager } from './managers/TabAlarmManager';
 import { BackgroundService } from './services/BackgroundService';
 import { chromeAlarmAPI } from './api/chromeAlarmAPI';
+import { chromeSessionStorageAPI } from './api/chromeSessionStorageAPI';
 
-const tabTimeoutManager = new TabAlarmManager(chromeAlarmAPI);
-const extensionIconService = new ExtensionActionManager(chromeActionAPI);
-const excludedTabManager = new ExcludedTabManager(extensionIconService);
+const tabAlarmManager = new TabAlarmManager(chromeAlarmAPI);
+const extensionActionManager = new ExtensionActionManager(chromeActionAPI);
+const excludedTabManager = new ExcludedTabManager(chromeSessionStorageAPI, extensionActionManager);
 const configurationManager = new ConfigurationManager(chromeSyncStorageAPI);
-const openedTabManager = new OpenedTabManager(chromeRuntimeAPI, chromeTabAPI, tabTimeoutManager, excludedTabManager, configurationManager);
+const openedTabManager = new OpenedTabManager(
+  chromeRuntimeAPI,
+  chromeTabAPI,
+  chromeSessionStorageAPI,
+  tabAlarmManager,
+  excludedTabManager,
+  configurationManager
+);
 
 new BackgroundService(chromeRuntimeAPI, chromeTabAPI, chromeActionAPI, openedTabManager, excludedTabManager).start();

--- a/src/helpers/CachedValue.ts
+++ b/src/helpers/CachedValue.ts
@@ -1,0 +1,36 @@
+﻿import { IBrowserStorageAPI } from '../api/IBrowserStorageAPI';
+import { BrowserStorageChange } from '../types';
+
+export class CachedValue<T> {
+  private _data: T | null = null;
+
+  constructor(
+    private readonly _browserStorageApi: IBrowserStorageAPI,
+    private readonly _storageKey: string,
+    private readonly _defaultValue?: T
+  ) {
+    this._browserStorageApi.onChanged.addListener(this.handleStorageChanged.bind(this));
+  }
+
+  public async get(): Promise<T | null> {
+    if (!this._data) {
+      const storage = await this._browserStorageApi.get({ [this._storageKey]: this._defaultValue });
+      this._data = storage[this._storageKey];
+    }
+
+    return this._data;
+  }
+
+  public async put(newData: T): Promise<void> {
+    this._data = newData;
+    await this._browserStorageApi.set({ [this._storageKey]: newData });
+  }
+
+  private handleStorageChanged(changes: { [key: string]: BrowserStorageChange }): void {
+    if (this._storageKey in changes) {
+      if (changes[this._storageKey].newValue) {
+        this._data = changes[this._storageKey].newValue;
+      }
+    }
+  }
+}

--- a/src/helpers/log.ts
+++ b/src/helpers/log.ts
@@ -1,0 +1,5 @@
+﻿export function logInfo(...args: unknown[]): void {
+  if (globalThis?.__DEBUG__) {
+    console.info(`[tab-reaper][${new Date().toISOString()}]`, ...args);
+  }
+}

--- a/src/managers/ExcludedTabManager.ts
+++ b/src/managers/ExcludedTabManager.ts
@@ -1,28 +1,38 @@
 import { TabId } from '../types';
 import { IExtensionActionManager } from './IExtensionActionManager';
 import { IExcludedTabManager } from './IExcludedTabManager';
+import { IBrowserStorageAPI } from '../api/IBrowserStorageAPI';
+import { CachedValue } from '../helpers/CachedValue';
 
 export class ExcludedTabManager implements IExcludedTabManager {
-  private excludedTabs: Set<TabId> = new Set();
+  private static readonly StorageKey = 'excludedTabs';
+  private readonly _excludedTabs: CachedValue<ReadonlyArray<TabId>>;
 
-  constructor(private readonly extensionIconService: IExtensionActionManager) {}
+  constructor(private readonly _browserStorageAPI: IBrowserStorageAPI, private readonly _extensionIconService: IExtensionActionManager) {
+    this._excludedTabs = new CachedValue<ReadonlyArray<TabId>>(this._browserStorageAPI, ExcludedTabManager.StorageKey, []);
+  }
 
-  public isExcluded(tabId: number): boolean {
-    return this.excludedTabs.has(tabId);
+  public async isExcluded(tabId: number): Promise<boolean> {
+    const excludedTabs = await this._excludedTabs.get();
+    return excludedTabs.includes(tabId);
   }
 
   public async exclude(tabId: number): Promise<void> {
-    this.excludedTabs.add(tabId);
-    await this.extensionIconService.disableExtensionIcon(tabId);
+    const excludedTabs = new Set(await this._excludedTabs.get());
+    excludedTabs.add(tabId);
+    await this._excludedTabs.put(Array.from(excludedTabs));
+    await this._extensionIconService.disableExtensionIcon(tabId);
   }
 
   public async include(tabId: number): Promise<void> {
-    this.excludedTabs.delete(tabId);
-    await this.extensionIconService.enableExtensionIcon(tabId);
+    const excludedTabs = new Set(await this._excludedTabs.get());
+    excludedTabs.delete(tabId);
+    await this._excludedTabs.put(Array.from(excludedTabs));
+    await this._extensionIconService.enableExtensionIcon(tabId);
   }
 
   public async toggle(tabId: number): Promise<void> {
-    if (this.isExcluded(tabId)) {
+    if (await this.isExcluded(tabId)) {
       await this.include(tabId);
     } else {
       await this.exclude(tabId);

--- a/src/managers/ExtensionActionManager.ts
+++ b/src/managers/ExtensionActionManager.ts
@@ -17,19 +17,19 @@ const enabledIconPaths = {
 };
 
 export class ExtensionActionManager implements IExtensionActionManager {
-  constructor(private readonly extensionActionAPI: IBrowserExtensionActionAPI) {}
+  constructor(private readonly _extensionActionAPI: IBrowserExtensionActionAPI) {}
 
   public async disableExtensionIcon(tabId?: TabId): Promise<void[]> {
     return Promise.all([
-      this.extensionActionAPI.setTitle({ tabId, title: 'Tab Reaper (off)' }),
-      this.extensionActionAPI.setIcon({ tabId, path: disabledIconPaths }),
+      this._extensionActionAPI.setTitle({ tabId, title: 'Tab Reaper (off)' }),
+      this._extensionActionAPI.setIcon({ tabId, path: disabledIconPaths }),
     ]);
   }
 
   public async enableExtensionIcon(tabId?: number): Promise<void[]> {
     return Promise.all([
-      this.extensionActionAPI.setTitle({ tabId, title: 'Tab Reaper' }),
-      this.extensionActionAPI.setIcon({ tabId, path: enabledIconPaths }),
+      this._extensionActionAPI.setTitle({ tabId, title: 'Tab Reaper' }),
+      this._extensionActionAPI.setIcon({ tabId, path: enabledIconPaths }),
     ]);
   }
 }

--- a/src/managers/IConfigurationManager.ts
+++ b/src/managers/IConfigurationManager.ts
@@ -1,10 +1,5 @@
 import { IConfiguration } from '../models/Configuration';
 
-export interface ConfigurationChange {
-  readonly newValue?: unknown;
-  readonly oldValue?: unknown;
-}
-
 export interface IConfigurationManager {
   get(): Promise<IConfiguration>;
   save(configuration: Partial<IConfiguration>): Promise<void>;

--- a/src/managers/IExcludedTabManager.ts
+++ b/src/managers/IExcludedTabManager.ts
@@ -1,7 +1,7 @@
 import { TabId } from '../types';
 
 export interface IExcludedTabManager {
-  isExcluded(tabId: TabId): boolean;
+  isExcluded(tabId: TabId): Promise<boolean>;
   exclude(tabId: TabId): Promise<void>;
   include(tabId: TabId): Promise<void>;
   toggle(tabId: TabId): Promise<void>;

--- a/src/managers/ITabAlarmManager.ts
+++ b/src/managers/ITabAlarmManager.ts
@@ -1,6 +1,7 @@
 import { TabId } from '../types';
 
 export interface ITabAlarmManager {
-  setAlarm(tabId: TabId, delayInMinutes: number, callback: () => void): Promise<void>;
+  setAlarm(tabId: TabId, delayInMinutes: number): Promise<void>;
   clearAlarm(tabId: TabId): Promise<void>;
+  onAlarm(callback: (tabId: TabId) => void): void;
 }

--- a/src/managers/OpenedTabManager.ts
+++ b/src/managers/OpenedTabManager.ts
@@ -5,26 +5,35 @@ import { IOpenedTabManager } from './IOpenedTabManager';
 import { IExcludedTabManager } from './IExcludedTabManager';
 import { ITabAlarmManager } from './ITabAlarmManager';
 import { IConfigurationManager } from './IConfigurationManager';
+import { logInfo } from '../helpers/log';
+import { emptyConfiguration } from '../models/Configuration';
+import { CachedValue } from '../helpers/CachedValue';
+import { IBrowserStorageAPI } from '../api/IBrowserStorageAPI';
 
 export class OpenedTabManager implements IOpenedTabManager {
-  private static TimeoutDurationMin = 15;
-  private previousActiveTabInWindow: Map<WindowId, TabId> = new Map();
+  private static readonly StorageKey = 'previousActiveTabByWindow';
+  private readonly _previousActiveTabByWindow: CachedValue<Record<WindowId, TabId>>;
 
   constructor(
-    private readonly browserRuntimeAPI: IBrowserRuntimeAPI,
-    private readonly browserTabAPI: IBrowserTabAPI,
-    private readonly tabAlarmManager: ITabAlarmManager,
-    private readonly excludedTabManager: IExcludedTabManager,
-    private readonly configurationManager: IConfigurationManager
+    private readonly _browserRuntimeAPI: IBrowserRuntimeAPI,
+    private readonly _browserTabAPI: IBrowserTabAPI,
+    private readonly _browserStorageAPI: IBrowserStorageAPI,
+    private readonly _tabAlarmManager: ITabAlarmManager,
+    private readonly _excludedTabManager: IExcludedTabManager,
+    private readonly _configurationManager: IConfigurationManager
   ) {
+    this._previousActiveTabByWindow = new CachedValue<Record<WindowId, TabId>>(this._browserStorageAPI, OpenedTabManager.StorageKey, {});
+
     this.watchAllTabs = this.watchAllTabs.bind(this);
     this.onTabActivated = this.onTabActivated.bind(this);
     this.onTabCreated = this.onTabCreated.bind(this);
     this.onTabRemoved = this.onTabRemoved.bind(this);
+
+    this._tabAlarmManager.onAlarm(this.removeTab.bind(this));
   }
 
   public async watchAllTabs(): Promise<void> {
-    const tabs = await this.browserTabAPI.query({ active: false });
+    const tabs = await this._browserTabAPI.query({ active: false });
 
     for (const { id } of tabs) {
       await this.planTabRemoval(id);
@@ -37,52 +46,64 @@ export class OpenedTabManager implements IOpenedTabManager {
 
   public async onTabActivated(activeInfo: TabActiveInfo): Promise<void> {
     const { windowId, tabId } = activeInfo;
-    await this.tabAlarmManager.clearAlarm(tabId);
+    await this._tabAlarmManager.clearAlarm(tabId);
 
-    const previousActiveId = this.previousActiveTabInWindow.get(windowId);
-    await this.planTabRemoval(previousActiveId);
+    const previousActiveIds = await this._previousActiveTabByWindow.get();
+    await this.planTabRemoval(previousActiveIds[windowId]);
 
-    this.previousActiveTabInWindow.set(windowId, tabId);
+    await this._previousActiveTabByWindow.put({ ...previousActiveIds, [windowId]: tabId });
   }
 
   public async onTabRemoved(tabId: TabId): Promise<void> {
-    await this.tabAlarmManager.clearAlarm(tabId);
+    await this._tabAlarmManager.clearAlarm(tabId);
   }
 
   private async removeTab(tabId: TabId): Promise<void> {
-    const tab = await this.browserTabAPI.get(tabId);
+    if (!tabId) {
+      return;
+    }
+
+    const tab = await this._browserTabAPI.get(tabId);
 
     if (await this.canRemoveTab(tab)) {
-      await this.browserTabAPI.remove(tabId);
+      await this._browserTabAPI.remove(tabId);
     } else if (!tab.active) {
       await this.planTabRemoval(tabId);
     }
   }
 
   private async planTabRemoval(tabId: TabId | undefined): Promise<void> {
-    if (!tabId || this.excludedTabManager.isExcluded(tabId)) {
+    if (!tabId || (await this._excludedTabManager.isExcluded(tabId))) {
       return;
     }
 
-    const removeAfterMinutes = (await this.configurationManager.get()).tabRemovalDelayMin ?? OpenedTabManager.TimeoutDurationMin;
-
-    await this.tabAlarmManager.setAlarm(tabId, removeAfterMinutes, () => {
-      this.removeTab(tabId);
-    });
+    const removeAfterMinutes = ((await this._configurationManager.get()) || emptyConfiguration).tabRemovalDelayMin;
+    await this._tabAlarmManager.setAlarm(tabId, removeAfterMinutes);
   }
 
   private async canRemoveTab(tab: Tab): Promise<boolean> {
     if (!tab || !tab.id) return false;
 
-    const configuration = await this.configurationManager.get();
+    // TODO: this is not the right approach, needs to be replaced with try/catch
+    const lastError = this._browserRuntimeAPI.getLastError();
+    if (lastError) {
+      logInfo('OpenedTabManager: tab cannot be removed because of the error: ', lastError);
+      return false;
+    }
 
-    const errorOccurred = this.browserRuntimeAPI.getLastError();
-    const isExcluded = this.excludedTabManager.isExcluded(tab.id);
-    const isActive = tab.active;
+    if (tab.active) {
+      return false;
+    }
+
+    if (await this._excludedTabManager.isExcluded(tab.id)) {
+      return false;
+    }
+
+    const configuration = await this._configurationManager.get();
     const makesSound = configuration.keepAudibleTabs && tab.audible;
     const isInGroup = configuration.keepGroupedTabs && tab.groupId != -1;
     const isPinned = configuration.keepPinnedTabs && tab.pinned;
 
-    return !errorOccurred && !isExcluded && !isPinned && !isActive && !makesSound && !isInGroup;
+    return !isPinned && !makesSound && !isInGroup;
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Tab Reaper: Idle Tab Collector",
   "description": "Automatically closes idle tabs, freeing up clutter and helping you stay focused on what matters most.",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "permissions": ["alarms", "tabs", "storage"],
   "icons": {
     "16": "./icons/icon-active-16.png",

--- a/src/models/Configuration.ts
+++ b/src/models/Configuration.ts
@@ -1,17 +1,17 @@
 export interface IConfiguration {
-  readonly version: '0.0.1';
-  readonly tabRemovalDelayMin: number;
-  readonly keepPinnedTabs: boolean;
-  readonly keepGroupedTabs: boolean;
   readonly keepAudibleTabs: boolean;
+  readonly keepGroupedTabs: boolean;
+  readonly keepPinnedTabs: boolean;
+  readonly tabRemovalDelayMin: number;
+  readonly version: '0.0.1';
 }
 
 export const emptyConfiguration: IConfiguration = {
-  version: '0.0.1',
-  tabRemovalDelayMin: 30,
-  keepPinnedTabs: true,
-  keepGroupedTabs: true,
   keepAudibleTabs: true,
+  keepGroupedTabs: true,
+  keepPinnedTabs: true,
+  tabRemovalDelayMin: 30,
+  version: '0.0.1',
 };
 
 export const toConfiguration = (obj: Partial<IConfiguration>): IConfiguration => ({

--- a/src/services/BackgroundService.ts
+++ b/src/services/BackgroundService.ts
@@ -8,11 +8,11 @@ import { IBackgroundService } from './IBackgroundService';
 
 export class BackgroundService implements IBackgroundService {
   constructor(
-    private readonly browserRuntimeAPI: IBrowserRuntimeAPI,
-    private readonly browserTabAPI: IBrowserTabAPI,
-    private readonly browserActionAPI: IBrowserExtensionActionAPI,
-    private readonly openedTabManager: IOpenedTabManager,
-    private readonly excludedTabManager: IExcludedTabManager
+    private readonly _browserRuntimeAPI: IBrowserRuntimeAPI,
+    private readonly _browserTabAPI: IBrowserTabAPI,
+    private readonly _browserActionAPI: IBrowserExtensionActionAPI,
+    private readonly _openedTabManager: IOpenedTabManager,
+    private readonly _excludedTabManager: IExcludedTabManager
   ) {}
 
   public start(): void {
@@ -22,20 +22,20 @@ export class BackgroundService implements IBackgroundService {
   }
 
   private addRuntimeEventListeners(): void {
-    this.browserRuntimeAPI.onInstalled.addListener(this.openedTabManager.watchAllTabs);
-    this.browserRuntimeAPI.onStartup.addListener(this.openedTabManager.watchAllTabs);
+    this._browserRuntimeAPI.onInstalled.addListener(this._openedTabManager.watchAllTabs);
+    this._browserRuntimeAPI.onStartup.addListener(this._openedTabManager.watchAllTabs);
   }
 
   private addActionEventListeners(): void {
-    this.browserActionAPI.onClicked.addListener((tab: Tab) => {
+    this._browserActionAPI.onClicked.addListener((tab: Tab) => {
       if (!tab.id) return;
-      this.excludedTabManager.toggle(tab.id);
+      this._excludedTabManager.toggle(tab.id);
     });
   }
 
   private addTabEventListeners(): void {
-    this.browserTabAPI.onCreated.addListener(this.openedTabManager.onTabCreated);
-    this.browserTabAPI.onActivated.addListener(this.openedTabManager.onTabActivated);
-    this.browserTabAPI.onRemoved.addListener(this.openedTabManager.onTabRemoved);
+    this._browserTabAPI.onCreated.addListener(this._openedTabManager.onTabCreated);
+    this._browserTabAPI.onActivated.addListener(this._openedTabManager.onTabActivated);
+    this._browserTabAPI.onRemoved.addListener(this._openedTabManager.onTabRemoved);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,8 @@ export type BrowserLastError = chrome.runtime.LastError;
 
 export type BrowserStorageChangedEvent = chrome.storage.StorageChangedEvent;
 
+export type BrowserStorageChange = chrome.storage.StorageChange;
+
 export type ExtensionInstalledEvent = chrome.runtime.RuntimeInstalledEvent;
 
 export type ExtensionStartupEvent = chrome.runtime.RuntimeEvent;

--- a/tests/managers/TabAlarmManager.spec.ts
+++ b/tests/managers/TabAlarmManager.spec.ts
@@ -16,32 +16,35 @@ describe('TabAlarmManager', () => {
   });
 
   describe('setAlarm', () => {
-    it('should set alarm and register a callback', async () => {
+    it('should set alarm', async () => {
       const tabId: TabId = 10;
       const delay = 5;
-      const spy = jasmine.createSpy('alarmCallback');
 
-      await tabAlarmManager.setAlarm(tabId, delay, spy);
-      expect(browserAlarmAPI.create).toHaveBeenCalledOnceWith(tabId.toString(), { delayInMinutes: delay });
-
-      (browserAlarmAPI.onAlarm.addListener as jasmine.Spy).calls.mostRecent().args[0]({ name: tabId.toString() });
-      expect(spy).toHaveBeenCalledTimes(1);
+      await tabAlarmManager.setAlarm(tabId, delay);
+      expect(browserAlarmAPI.create).toHaveBeenCalledOnceWith(`tab:${tabId}`, { delayInMinutes: delay });
     });
 
-    it('should clear previously set alarm and callback', async () => {
+    it('should clear previously set alarm', async () => {
       const tabId: TabId = 10;
       const delay = 5;
 
-      const oldSpy = jasmine.createSpy('oldAlarmCallback');
-      await tabAlarmManager.setAlarm(tabId, delay, oldSpy);
+      await tabAlarmManager.setAlarm(tabId, delay);
       browserAlarmAPI.clear.calls.reset();
 
-      const newSpy = jasmine.createSpy('newAlarmCallback');
-      await tabAlarmManager.setAlarm(tabId, delay, newSpy);
-      expect(browserAlarmAPI.clear).toHaveBeenCalledWith(tabId.toString());
+      await tabAlarmManager.setAlarm(tabId, delay);
+      expect(browserAlarmAPI.clear).toHaveBeenCalledWith(`tab:${tabId}`);
+    });
+  });
 
-      (browserAlarmAPI.onAlarm.addListener as jasmine.Spy).calls.mostRecent().args[0]({ name: tabId.toString() });
-      expect(oldSpy).toHaveBeenCalledTimes(0);
+  describe('onAlarm', () => {
+    it('should add alarm listener', async () => {
+      const tabId: TabId = 10;
+      const spy = jasmine.createSpy('alarmCallback');
+
+      await tabAlarmManager.onAlarm(spy);
+
+      (browserAlarmAPI.onAlarm.addListener as jasmine.Spy).calls.mostRecent().args[0]({ name: `tab:${tabId}` });
+      expect(spy).toHaveBeenCalledOnceWith(tabId);
     });
   });
 });


### PR DESCRIPTION
When using manifest v3, background scripts are non-persistent, which means that they are deactivated after a period of time. That is why all state should be persisted in a storage (local, session, sync) to avoid losing it when the scripts becomes inactive.